### PR TITLE
게시글 수정 버그

### DIFF
--- a/src/main/java/com/fastcampus/fastcampusprojectboard/domain/Article.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/domain/Article.java
@@ -57,8 +57,8 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/domain/ArticleComment.java
@@ -50,7 +50,7 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/domain/UserAccount.java
@@ -45,8 +45,8 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override


### PR DESCRIPTION
- 게시글이 정상적으로 수정되지 않는 버그를 수정했다.
- entity 간의 equals()로 비교 시 정상적으로 수행되지 않아, if문을 통과하지 못하고 게시글 수정 메소드를 종료하고 있었다.